### PR TITLE
Add hunspell and remove liblzma as prerequisites for OS X

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -24,12 +24,12 @@ Install the build prerequisites:
 
 Proceed with the `General Procedure` section.
 
-## Mac OS X
+## Mac OS X / macOS
 Install the build prerequisites:
 
 1. XCode and the XCode command line developer tools
 2. MacPorts, Homebrew, or Fink
-3. From one of those package managers, install `autoconf automake sbcl git gettext pcre openssl libtool gnu-sed glfw libgcrypt pkg-config xz liblzma`, making sure they are in your `PATH`.
+3. From one of those package managers, install `autoconf automake sbcl git gettext pcre openssl libtool gnu-sed glfw libgcrypt pkg-config xz hunspell`, making sure they are in your `PATH`.
 4. With brew, you need to link gettext: `brew link gettext --force`
 
 Proceed with the `General Procedure` section.


### PR DESCRIPTION
If hunspell is missing,
```
Error enabling Flyspell mode:
(portacle/mac/bin/hunspell exited with signal Trace/BPT trap: 5)
```
is shown every time a file is loaded into Emacs.

liblzma is in xz.
(Also added macOS to heading.)