### PR TITLE
Add native GitHub "Sponsor" button linking to your GitHub Sponsors and Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: Shinmera
+ko_fi: shinmera


### PR DESCRIPTION
Simply merge this pull request and activate the "Sponsorships" option in Portacle's project settings to get a cute little "Sponsor" button linking to your [GitHub Sponsors](https://github.com/sponsors/Shinmera) and [Ko-fi](https://ko-fi.com/shinmera)!

Here's a [preview](https://github.com/Hexstream/portacle) of the end result.

Here's the [official documentation](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for this nice feature.

Obviously, consider also doing this for any other suitable repos.

PS: When does your GitHub Sponsors doubling expire? This would be one year after you got accepted, I believe. Also, you should definitely support higher tiers...