### PR TITLE
Use default community health files for Portacle organization.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: Shinmera
-ko_fi: shinmera


### PR DESCRIPTION
This is a follow-up to #133, thank you for the quick merge.

Since you have tons of projects, you'll probably want to use the great [default community health files feature](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file). This notably allows you to set a default `FUNDING.yml` file for an entire account or organization. You would probably want to use this for [your account](https://github.com/Shinmera), [the Portacle organization](https://github.com/portacle) and [the Shirakumo organization](https://github.com/Shirakumo). You then only need to activate the "Sponsorships" option in each suitable project's settings, and you still have the flexibility of overriding the defaults (or disabling funding) in each individual project as needed. (Don't forget to delete now redundant community health files in your projects so that any future changes to the defaults are appropriately reflected in all suitable projects.)

I recently adopted this method for all my projects and it works great!

Simply create a `.github` repository [like this](https://github.com/Hexstream/.github) in the appropriate locations, of course substituting [your own funding details](https://github.com/portacle/portacle/blob/d6f398d0c2e8961263d4bc763da0afb7c2ef7764/.github/FUNDING.yml), and then merge this pull request. :)