### PR TITLE
Adding texinfo and go to required macOS package dependencies

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -29,7 +29,7 @@ Install the build prerequisites:
 
 1. XCode and the XCode command line developer tools
 2. MacPorts, Homebrew, or Fink
-3. From one of those package managers, install `autoconf automake sbcl git gpg gettext pcre openssl libtool gnu-sed glfw libgcrypt pkg-config xz automake gnutls pcre2 libassuan`, making sure they are in your `PATH`.
+3. From one of those package managers, install `autoconf automake sbcl git gpg gettext pcre openssl libtool gnu-sed glfw libgcrypt pkg-config xz automake gnutls pcre2 libassuan texinfo go`, making sure they are in your `PATH`.
 4. With brew, you need to link gettext: `brew link gettext --force`
 
 Proceed with the `General Procedure` section.


### PR DESCRIPTION
I just cloned and built portacle from scratch, and needed to include both of these homebrew dependencies for it to finish. I still had a few small issues with signing something, and it looks just slightly different than the current portacle binary, but pretty good nonetheless.